### PR TITLE
CHANGE(oio-meta2-indexer): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ An Ansible role for OpenIO oio-meta2-indexer. Specifically, the responsibilities
 | `openio_meta2_indexer_interval` | `3000` | Time between two full scans for each volume |
 | `openio_meta2_indexer_namespace` | `"OPENIO"` | Namespace |
 | `openio_meta2_indexer_provision_only` | `false` | Provision only without restarting services |
+| `openio_meta2_indexer_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 | `openio_meta2_indexer_report_interval` | `5` | Time between progress reports for each volume |
 | `openio_meta2_indexer_serviceid` | `"0"` | ID in gridinit |
 | `openio_meta2_indexer_volume_list` | `[]` | List of paths pointing to meta2 volumes to index |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,5 +11,6 @@ openio_meta2_indexer_scanned_per_second: 2
 openio_meta2_indexer_interval: 3000
 
 openio_meta2_indexer_provision_only: false
+openio_meta2_indexer_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 openio_meta2_indexer_volume_list: []
 ...

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_meta2_indexer_package_upgrade else 'present' }}"
   with_items: "{{ meta2_indexer_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_meta2_indexer_package_upgrade else 'present' }}"
   with_items: "{{ meta2_indexer_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION