### PR TITLE
CHANGE(oio-meta2-indexer): move variables from `vars` to `default`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,3 @@
-# roles/meta2_indexer/defaults/main.yml
 ---
 openio_meta2_indexer_namespace: "OPENIO"
 openio_meta2_indexer_serviceid: "0"
@@ -13,4 +12,11 @@ openio_meta2_indexer_interval: 3000
 openio_meta2_indexer_provision_only: false
 openio_meta2_indexer_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 openio_meta2_indexer_volume_list: []
+
+openio_meta2_indexer_sysconfig_dir: "/etc/oio/sds/{{ openio_meta2_indexer_namespace }}"
+openio_meta2_indexer_servicename: "oio-meta2-indexer-{{ openio_meta2_indexer_serviceid }}"
+
+openio_meta2_indexer_definition_file: >
+  "{{ openio_meta2_indexer_sysconfig_dir }}/
+  {{ openio_meta2_indexer_servicename }}/{{ openio_meta2_indexer_servicename }}.conf"
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,2 @@
 ---
-openio_meta2_indexer_sysconfig_dir: "/etc/oio/sds/{{ openio_meta2_indexer_namespace }}"
-openio_meta2_indexer_servicename: "oio-meta2-indexer-{{ openio_meta2_indexer_serviceid }}"
-
-openio_meta2_indexer_definition_file: >
-  "{{ openio_meta2_indexer_sysconfig_dir }}/
-  {{ openio_meta2_indexer_servicename }}/{{ openio_meta2_indexer_servicename }}.conf"
 ...


### PR DESCRIPTION
 ##### SUMMARY
in `vars` should only remain variables that must be fixed.
All the others must be set in `defaults` (almost all variables).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION